### PR TITLE
Framework fix for retrieving storage details

### DIFF
--- a/analytics-core/src/main/scala/org/ekstep/analytics/framework/FrameworkContext.scala
+++ b/analytics-core/src/main/scala/org/ekstep/analytics/framework/FrameworkContext.scala
@@ -44,7 +44,7 @@ class FrameworkContext {
       return null;
     }
     if (!storageContainers.contains(storageType + "|" + storageKey)) {
-      storageContainers.put(storageType + "|" + storageKey, StorageServiceFactory.getStorageService(org.sunbird.cloud.storage.factory.StorageConfig(storageType, AppConf.getConfig(storageKey), AppConf.getConfig(storageSecret))));
+      storageContainers.put(storageType + "|" + storageKey, StorageServiceFactory.getStorageService(org.sunbird.cloud.storage.factory.StorageConfig(storageType, AppConf.getStorageKey(storageKey), AppConf.getStorageSecret(storageSecret))));
     }
     storageContainers.get(storageType + "|" + storageKey).get
   }

--- a/analytics-core/src/main/scala/org/ekstep/analytics/framework/conf/AppConf.scala
+++ b/analytics-core/src/main/scala/org/ekstep/analytics/framework/conf/AppConf.scala
@@ -29,4 +29,14 @@ object AppConf {
         getConfig("aws_secret");
     }
 
+    def getStorageKey(`type`: String): String = {
+        if (`type`.equals("azure")) getConfig("azure_storage_key");
+        else "";
+    }
+
+    def getStorageSecret(`type`: String): String = {
+        if (`type`.equals("azure")) getConfig("azure_storage_secret");
+        else "";
+    }
+
 }


### PR DESCRIPTION
`AppConf.getConfig(storageKey)` -  here **storageKey** will just have **azure** as value. This fails for empty keys.