### PR TITLE
fix(deps): patch Dependabot CVEs — high/medium/low severity

### DIFF
--- a/analytics-core/pom.xml
+++ b/analytics-core/pom.xml
@@ -160,15 +160,16 @@
 			<scope>test</scope>
 		</dependency>
 		<!-- -->
+		<!-- CVE-2026-34477/34478/34480/34479 (MED): log4j-core/api patched at 2.25.4 -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.25.3</version>
+			<version>2.25.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.25.3</version>
+			<version>2.25.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
@@ -274,10 +275,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<!-- CVE-2026-35554 (HIGH, CVSS 8.7): kafka-clients vulnerable >= 2.8.0, < 3.9.2 -->
 		<dependency>
 		    <groupId>org.apache.kafka</groupId>
 		    <artifactId>kafka_${scala.maj.version}</artifactId>
-		    <version>3.9.1</version>
+		    <version>3.9.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>

--- a/analytics-core/src/test/scala/org/ekstep/analytics/framework/util/TestDatasetUtil.scala
+++ b/analytics-core/src/test/scala/org/ekstep/analytics/framework/util/TestDatasetUtil.scala
@@ -105,6 +105,9 @@ class TestDatasetUtil extends BaseSpec with Matchers with MockFactory {
           case _: IOException => println("S3 Exception occurred")
           case _: Exception => println("Exception occurred")
           case illegalArgumentException: IllegalArgumentException => println("CSP Configurations are not found")
+          // Hadoop 3.4.x throws NoClassDefFoundError (an Error) for missing filesystem classes
+          // (e.g. NativeAzureFileSystem absent from classpath), whereas 3.3.x wrapped in RuntimeException
+          case _: Error => println("Storage filesystem class not found")
           case _ =>
             fail("Unexpected exception type thrown")
         }

--- a/analytics-job-driver/pom.xml
+++ b/analytics-job-driver/pom.xml
@@ -130,6 +130,13 @@
 			<artifactId>lz4-java</artifactId>
 			<version>1.8.1</version>
 		</dependency>
+		<!-- CVE-2025-66566 (HIGH): at.yawk.lz4 groupId (distinct Maven coordinates from org.lz4).
+		     Patched at >= 1.10.1; pinned at 1.10.4 to align with analytics-core and batch-models. -->
+		<dependency>
+			<groupId>at.yawk.lz4</groupId>
+			<artifactId>lz4-java</artifactId>
+			<version>1.10.4</version>
+		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>
 			<artifactId>scalatest_${scala.maj.version}</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,14 @@
 		<scala.version>2.13.14</scala.version>
 		<spark.maj.version>3.5</spark.maj.version>
 		<spark.version>3.5.8</spark.version>
-		<hadoop.version>3.3.4</hadoop.version>
-		<!-- CVE-2025-52999 (HIGH), CVE-2025-49128 (MED), GHSA-72hv-8253-57qq (MED):
-		     Aligned with Spark 3.5.8 bundled Jackson 2.15.4 at runtime — the declared
-		     version here governs compile-time resolution only; shaded JARs already exclude
-		     com/fasterxml/jackson/**. Residual risk remains for the Spark-bundled version. -->
-		<jackson.version>2.15.4</jackson.version>
+		<!-- CVE-2024-23454 (LOW, CVSS 3.3): hadoop-common patched at 3.4.0; using 3.4.3 (latest).
+		     All hadoop deps are provided scope — runtime cluster must supply >= 3.4.0 for actual fix. -->
+		<hadoop.version>3.4.3</hadoop.version>
+		<!-- jackson-core GHSA (MED): patched version 2.18.6 not yet on Maven Central; using 2.19.0
+		     (latest stable, > 2.18.5 vulnerable range). Compile-time only — shaded JARs exclude
+		     com/fasterxml/jackson/**. Spark 3.5.8 bundles Jackson 2.15.4 at runtime (still vulnerable;
+		     requires Spark upgrade to fully remediate). -->
+		<jackson.version>2.19.0</jackson.version>
 		<paranamer.version>2.8</paranamer.version>
 	</properties>
 
@@ -172,6 +174,46 @@
 				<groupId>org.bouncycastle</groupId>
 				<artifactId>bcprov-jdk15on</artifactId>
 				<version>1.70</version>
+			</dependency>
+			<!-- CVE-2026-35554 (HIGH, CVSS 8.7): kafka-clients vulnerable >= 2.8.0, < 3.9.2 -->
+			<dependency>
+				<groupId>org.apache.kafka</groupId>
+				<artifactId>kafka-clients</artifactId>
+				<version>3.9.2</version>
+			</dependency>
+			<!-- CVE-2023-1370 (HIGH, CVSS 7.5): json-smart vulnerable < 2.4.9 -->
+			<dependency>
+				<groupId>net.minidev</groupId>
+				<artifactId>json-smart</artifactId>
+				<version>2.4.9</version>
+			</dependency>
+			<!-- CVE-2026-34477/34478/34480 (MED), CVE-2026-34479 (MED): log4j-core/api/1.2-api vulnerable < 2.25.4 -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>2.25.4</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>2.25.4</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-1.2-api</artifactId>
+				<version>2.25.4</version>
+			</dependency>
+			<!-- CVE-2021-34429 (MED, CVSS 5.3): jetty-webapp vulnerable >= 9.4.37, < 9.4.43; pin 9.4.57 satisfies -->
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-webapp</artifactId>
+				<version>9.4.57.v20241219</version>
+			</dependency>
+			<!-- LOW: jetty-xml vulnerable <= 9.4.51; pin 9.4.57 satisfies patched >= 9.4.52 -->
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-xml</artifactId>
+				<version>9.4.57.v20241219</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,13 @@
 				<artifactId>bcprov-jdk15on</artifactId>
 				<version>1.70</version>
 			</dependency>
+			<!-- jackson-module-scala must match jackson.version to avoid ClassLoader conflict;
+			     cloud-storage-sdk-aws brings 2.16.2 transitively — override to align with 2.19.0 -->
+			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-scala_${scala.maj.version}</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
 			<!-- CVE-2026-35554 (HIGH, CVSS 8.7): kafka-clients vulnerable >= 2.8.0, < 3.9.2 -->
 			<dependency>
 				<groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## Summary

- **CVE-2026-35554** (HIGH, CVSS 8.7): `kafka-clients` 3.9.1 → 3.9.2; `kafka_2.13` direct dep bumped to align
- **CVE-2023-1370** (HIGH, CVSS 7.5): `net.minidev:json-smart` pinned ≥ 2.4.9 via root `dependencyManagement`
- **CVE-2025-66566** (HIGH): `at.yawk.lz4:lz4-java` 1.10.4 added explicitly to `analytics-job-driver` (already present in other modules)
- **CVE-2026-34477/34478/34480/34479** (MEDIUM): `log4j-core`, `log4j-api`, `log4j-1.2-api` bumped 2.25.3 → 2.25.4
- **CVE-2021-34429** (MEDIUM, CVSS 5.3): `jetty-webapp` 9.4.57 pinned via `dependencyManagement` (satisfies patched ≥ 9.4.43)
- **jackson-core GHSA** (MEDIUM): compile-time version 2.15.4 → 2.19.0 (patched=2.18.6 not yet on Maven Central; 2.19.0 is next safe release). `jackson-module-scala` also upgraded to 2.19.0 in `dependencyManagement` to resolve transitive conflict with `cloud-storage-sdk-aws`.
- **CVE-2024-23454** (LOW, CVSS 3.3): `hadoop.version` 3.3.4 → 3.4.3 (all hadoop deps are `provided` scope)
- **LOW (jetty-xml)**: `jetty-xml` 9.4.57 pinned via `dependencyManagement` (satisfies patched ≥ 9.4.52)

### Cannot fix (patch not yet released on Maven Central)

| CVE | Package | Patched version | Reason |
|-----|---------|----------------|--------|
| CVE-2026-2332 (HIGH, 7.4) | `jetty-http` | 9.4.60 | Not released on Maven Central (latest: 9.4.57) |
| CVE-2025-67721 (HIGH) | `aircompressor` | 2.0.3 | Not released on Maven Central (latest: 2.0.2) |
| CVE-2024-6763 (MED, 3.7) | `jetty-http` | 12.0.12 | Requires Jetty major upgrade — incompatible with Spark 3.5.x (bundles Jetty 9.x) |
| CVE-2025-11143 (LOW) | `jetty-http` | none | No patch available |

### Runtime action needed

- **hadoop-common** (CVE-2024-23454): `provided` scope — cluster/container must supply `hadoop-common >= 3.4.0` for the fix to take effect at runtime.
- **jackson-core GHSA**: Spark 3.5.8 bundles Jackson 2.15.4 at runtime (still in vulnerable range). Fully remediating requires a Spark upgrade.

## Test plan

- [x] `analytics-core` build: SUCCESS
- [x] `analytics-core` tests: 72/73 pass (1 pre-existing AWS credentials failure — `TestFrameworkContext`)
- [x] `analytics-job-driver` build: SUCCESS
- [x] `analytics-job-driver` tests: 12/13 pass (1 pre-existing AWS credentials failure — `TestJobDriver2`)
- [x] `batch-models` build: SUCCESS
- [x] `batch-models` tests: 19/19 pass
- [x] Full root build (`mvn clean install -DskipTests`): SUCCESS
- [x] `TestDatasetUtil` updated: Hadoop 3.4.x throws `Error` (not `Exception`) for missing Azure filesystem class — added `case _: Error` branch